### PR TITLE
Remove explicit `llvmlite` dep to fix Conda resolution on `osx-64`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - '1'
         os:
           - ubuntu-latest
@@ -21,6 +21,13 @@ jobs:
           - macos-latest
         arch:
           - x64
+        include:
+          - os: macos-latest
+            arch: aarch64
+            version: '1.10'
+          - os: macos-latest
+            arch: aarch64
+            version: '1'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,4 +1,4 @@
-channels = ["conda-forge"]
+channels = ["conda-forge", "numba"]
 
 [deps]
 pyod = "=2"

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,8 +1,4 @@
-channels = ["conda-forge", "numba"]
+channels = ["conda-forge"]
 
 [deps]
 pyod = "=2"
-
-[deps.llvmlite]
-channel = "numba"
-build = "*"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OutlierDetectionPython"
 uuid = "2449c660-d36c-460e-a68b-92ab3c865b3e"
 authors = ["David Muhr <muhrdavid@gmail.com> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 OutlierDetectionInterface = "1722ece6-f894-4ffc-b6be-6ca1174e2011"


### PR DESCRIPTION
Ref https://github.com/JuliaAI/MLJModelRegistryTools.jl/issues/10

Remove explicit `llvmlite` dep and `numba` channel from CondaPkg.toml. Pinning `llvmlite` to the `numba` channel causes resolution failures on osx-64 when Python is pinned to 3.13 (numba channel's `llvmlite` builds are lagging behind conda-forge).

@ablaom Let me know if this fixes it for you. I tested the resolution with pixi targeting `osx-64` from an ARM machine and verified the old config fails with your error and the new config works.